### PR TITLE
Fixes to workflows tutorial code

### DIFF
--- a/WORKFLOWS/Tutorials/Helloworld/.meta_Helloworld.xml
+++ b/WORKFLOWS/Tutorials/Helloworld/.meta_Helloworld.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1513013788764</value>
+            <value>1536570920931</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/WORKFLOWS/Tutorials/Helloworld/.meta_Helloworld.xml
+++ b/WORKFLOWS/Tutorials/Helloworld/.meta_Helloworld.xml
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1536570920931</value>
+            <value>1536573467025</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/WORKFLOWS/Tutorials/Helloworld/Helloworld.xml
+++ b/WORKFLOWS/Tutorials/Helloworld/Helloworld.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ObjectDefinition>  <information>
+    <allowLaunchOnFailedProcess>true</allowLaunchOnFailedProcess>
     <description/>
     <displayField>service_id</displayField>
     <executionDetailsVisibility>5</executionDetailsVisibility>
@@ -21,8 +22,9 @@
     <icon/>
     <allowSchedule>false</allowSchedule>
     <type>CREATE</type>
-    <task name="Task_init.php">
-      <processPath>/opt/fmc_repository/Process/Helloworld/Process_create_instance/Tasks/</processPath>
+    
+  <task name="/opt/fmc_repository/Process/OpenMSA/Tutorials/Helloworld/Process_create_instance/Tasks/Task_init.php">
+      <processPath>/opt/fmc_repository/Process/Helloworld/Process_create_instance</processPath>
       <displayName>init</displayName>
     </task>
   </process>
@@ -32,7 +34,8 @@
     <icon/>
     <allowSchedule>false</allowSchedule>
     <type>DELETE</type>
-    <task name="Task_delete.php">
+    
+  <task name="/opt/fmc_repository/Process/OpenMSA/Tutorials/Helloworld/Process_delete_instance/Tasks/Task_delete.php">
       <processPath>/opt/fmc_repository/Process/Helloworld/Process_delete_instance/Tasks/</processPath>
       <displayName>delete</displayName>
     </task>
@@ -43,7 +46,9 @@
     <icon/>
     <allowSchedule>false</allowSchedule>
     <type>UPDATE</type>
-    <task name="Task_print.php">
+    
+  
+  <task name="/opt/fmc_repository/Process/OpenMSA/Tutorials/Helloworld/Process_print_message/Tasks/Task_print.php">
       <processPath>/opt/fmc_repository/Process/Helloworld/Process_print_message/Tasks/</processPath>
       <displayName>print</displayName>
     </task>

--- a/WORKFLOWS/Tutorials/Helloworld/Process_create_instance/Tasks/.meta_Task_init.php
+++ b/WORKFLOWS/Tutorials/Helloworld/Process_create_instance/Tasks/.meta_Task_init.php
@@ -7,7 +7,7 @@
         </entry>
         <entry>
             <key>DATE_MODIFICATION</key>
-            <value>1513011094320</value>
+            <value>1536570873262</value>
         </entry>
         <entry>
             <key>COMMENT</key>

--- a/WORKFLOWS/Tutorials/Helloworld/Process_create_instance/Tasks/Task_init.php
+++ b/WORKFLOWS/Tutorials/Helloworld/Process_create_instance/Tasks/Task_init.php
@@ -10,12 +10,23 @@ require_once '/opt/fmc_repository/Process/Reference/Common/common.php';
  */
 function list_args()
 {
- 
+  create_var_def('name', 'String');
 }
+
+check_mandatory_param('name');
+
+/**
+ * get the value of name from the context and create a variable out of it
+ */
+$name=$context['name'];
+/**
+ * print the value in the log file /opt/jboss/latest/log/process.log 
+ */
+logToFile($name);
 
 /**
  * End of the task do not modify after this point
  */
-task_exit(ENDED, "workflow initialised");
+task_exit(ENDED, "Hello " . $name);
 
 ?>


### PR DESCRIPTION
Fixes to  `WORKFLOWS/Tutorials/Helloworld/`
- Task_init.php
- Helloworld.xml

Paths to Tasks are aligned with the OpenMSA/WFMS repo installation
as recommended in top-level README i.e. the local clone to this repository
is `symlinked` into the live MSA `/opt/fmc_repository` structure.